### PR TITLE
Fix Chrome Bug

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -15,7 +15,7 @@
             <table
                 data-scrolling-table
                 data-table-empty="No items found."
-                width="100%" height="250" >
+                style="width: 100%; max-height: 250px;">
                 <thead>
                     <tr>
                         <th data-column-sortable data-col="rate">Name</th>
@@ -74,7 +74,7 @@
             <table
                 data-scrolling-table
                 data-table-empty="No items found."
-                width="100%" height="250" >
+                style="width: 100%; max-height: 250px;">
                 <thead>
                     <tr>
                         <th data-column-sortable data-col="rate">Name</th>
@@ -133,7 +133,7 @@
             <table
                 data-scrolling-table
                 data-table-empty="No items found."
-                width="100%" height="250" >
+                style="width: 100%; max-height: 250px;">
                 <thead>
                     <tr>
                         <th data-column-sortable data-col="rate">Name</th>

--- a/src/directives/scrolling-table.js
+++ b/src/directives/scrolling-table.js
@@ -53,11 +53,11 @@
         var linker = function(scope, element, attrs) {
 
             var modelData = (attrs.data) ? attrs.data : 'data';
-            var maxHeight = element.css('height');
-            element.css('height', 0);
 
             var wrapper = element.wrap('<div class="tableWrapper"><div class="scroller"></div></div>').parents('.tableWrapper');
+            var maxHeight = element.css('max-height');
             wrapper.find('.scroller').css('max-height', maxHeight);
+            element.css('max-height', 0);
             wrapper.attr('id', tableUUID);
 
             var debounceId;
@@ -101,10 +101,8 @@
         function calculateDimensions(wrapDiv) {
             var header = wrapDiv.find('thead');
             var body = wrapDiv.find("tbody");
-            var innerWrap = body.parents('div.scroller');
             var h = header.find('tr').height();
             h = (h > 0) ? h : 25;
-            innerWrap.height(wrapDiv.height() - h);
             calculateWidths(wrapDiv);
         }
 
@@ -117,7 +115,6 @@
                     var padding = 0;
                     var desiredWidth = $(allBodyCols[index]).width();
                     $(this).css('width', desiredWidth);
-                    //$(this).css('min-width', desiredWidth);
                 });
             }
         }


### PR DESCRIPTION
- Change use of height to max-height in example an in Chrome element.css('height') returns the actual rendered height, not the CSS value.
