### PR TITLE
Move code that modifies the DOM into the compile function.

### DIFF
--- a/src/directives/scrolling-table.js
+++ b/src/directives/scrolling-table.js
@@ -95,8 +95,10 @@
                 for (var i=0; i < allMinWidthHeaders.length; i++) {
                     var columnRule = nzCssRuleEditor.getRule('#' + tableUUID + ' .tableHeader th:nth-child(' + (i+1) + ')');
                     columnRule.minWidth = $(allMinWidthHeaders[i]).width() + 'px';
+                    /* Causes longer table rendering times
                     var columnRule = nzCssRuleEditor.getRule('#' + tableUUID + ' .scroller td:nth-child(' + (i+1) + ')');
                     columnRule.minWidth = $(allMinWidthHeaders[i]).width() + 'px';
+                    */
                 }
                 cloneHead.remove();
             }, 0, false);


### PR DESCRIPTION
- The element passed to the link function is now the DOM we expect the final element to have.
- Use 'pre' instead of 'link' as then it will be processed before all child directives. This is needed so the that the final table is fully initallized before processing child element.
