### PR TITLE
Retain columns for rows in an array

### DIFF
--- a/src/directives/scrolling-table.js
+++ b/src/directives/scrolling-table.js
@@ -26,21 +26,6 @@
         }
     });
 
-    tables.directive('tableRow', function($compile) {
-        return {
-            restrict: 'A',
-            priority: 99,
-            compile: function($element, attrs, transclude) {
-                return {
-                    pre: function(scope, element, attrs) {
-                        element.after($compile( scope[attrs.tableRow].join('') )(scope));
-                        element.remove();
-                    }
-                }
-            },
-        }
-    });
-
     tables.directive('scrollingTable', function($timeout, $window, $compile, nzCssRuleEditor, tableService) {
         function calculateDimensions(wrapDiv) {
             var header = wrapDiv.find('thead');
@@ -102,7 +87,7 @@
                     headersElemArray.push(wrapper.outerHTML.match(regexOnlyTagData)[0]);
                 });
                 $(headerRows[0]).empty();
-                $(headerRows[0]).append('<td table-row="headersElemArray"></td>');
+                $(headerRows[0]).append( $( headersElemArray.join('') ) );
 
                 var bodyRows = wrapper.find('tbody tr');
                 var bodyElemArray = [];
@@ -110,7 +95,7 @@
                     bodyElemArray.push(wrapper.outerHTML.match(regexOnlyTagData)[0]);
                 });
                 $(bodyRows[0]).empty();
-                $(bodyRows[0]).append('<td table-row="bodyElemArray"></td>');
+                $(bodyRows[0]).append( $( bodyElemArray.join('') ) );
 
                 return {
                     // Is run BEFORE child directives.


### PR DESCRIPTION
Retain columns for rows in an array so the columns can be reordered and the table re-rendered.
- Add the min data column size back. It is no longer in a $timeout and does not seem to affect render time.

Jason, what are your thoughts about this. Do you have a different idea about how we can allow column reordering?
