### PR TITLE
The modelData is a collection for tables and should be watched as such.

### DIFF
--- a/src/directives/scrolling-table.js
+++ b/src/directives/scrolling-table.js
@@ -130,7 +130,7 @@
                         $($window).resize(function() {
                             recalcFn();
                         });
-                        scope.$watch(modelData, function() {
+                        scope.$watchCollection(modelData, function() {
                             recalcFn();
                         });
 


### PR DESCRIPTION
- Change the $watch to watch a collection.
- Fixes issue where table is not auto-formatted on initial display
