### PR TITLE
CSS Cleanup

### DIFF
--- a/src/less/scrolling-table.less
+++ b/src/less/scrolling-table.less
@@ -4,7 +4,7 @@
 .tableWrapper {
     width: 100%;
     position: relative;
-    top: 34px;
+    top: 0px;
     left: 0;
     right: 0;
     bottom: 0px;
@@ -85,8 +85,3 @@
     }
 }
 
-td.fixed {
-    width: 15px;
-    max-width: 15px;
-    min-width: 15px;
-}


### PR DESCRIPTION
- Remove erroneous top:34px from wrapper (was for toolbar but the wrapper
  is inside the toolbar)
- Removed un-used fixed class
