### PR TITLE
Fix the height setting of the scrollWrapper

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -20,7 +20,7 @@
             <table
                 data-stg-scrolling-table
                 data-stg-table-empty="No items found."
-                style="width: 100%; max-height: 250px;">
+                style="width: 100%; ">
                 <thead>
                     <tr>
                         <th data-column-sortable data-col="rate">Name</th>
@@ -48,7 +48,7 @@
                     </tr>
                 </thead>
                 <tbody >
-                    <tr data-ng-repeat="c in data | limitTo: 1 track by $index" >
+                    <tr data-ng-repeat="c in data | limitTo: 5 track by $index" >
                         <td>{{c.name}}</td>
                         <td>{{c.phoneNumber.slice(0, 2)}}</td>
                         <td width="100px">{{c.phoneNumber.slice(0, 2)}}</td>

--- a/src/less/scrolling-table.less
+++ b/src/less/scrolling-table.less
@@ -13,6 +13,7 @@
         overflow-y: auto;
         overflow-x: hidden;
         background-color: @color-background;
+        border-bottom: 1px @color-table-cellBorder solid;
         
         td {
             border: @table-border-tablecell;


### PR DESCRIPTION
- set both max-height and height on the tableWrapper div
- listen for a resize on the tableWapper and if so calculate the scroller
  height to be the tableWrapper height - header.  The listener is
  debounced if happening too often.
- remove the max-height on the first table and set limit to 5 on example
- add a bottom border for the scroller for a more polished look
