### PR TITLE
Adding the column group handling

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -83,7 +83,7 @@
                 style="width: 100%; max-height: 250px;">
                 <thead>
                     <tr>
-                        <th stg-table-highlight-column data-column-sortable data-col="rate">Name</th>
+                        <th stg-table-highlight-column data-column-sortable data-col="rate" width="250px">Name</th>
                         <th stg-table-highlight-column width="100px">Phone Number</th>
                         <th stg-table-highlight-column>Phone Number</th>
                         <th stg-table-highlight-column>Phone Number</th>

--- a/src/less/scrolling-table.less
+++ b/src/less/scrolling-table.less
@@ -17,6 +17,7 @@
         
         td {
             border: @table-border-tablecell;
+            overflow: hidden;
         }
         tr {
             display: table-row;
@@ -44,12 +45,8 @@
     }
 
     .tableHeader {
-        width: 100%;
         overflow: hidden;
         .gradient(@color-gradient-light, @color-gradient-dark, @color-gradient-light);
-        table {
-            table-layout: fixed;
-        }
         tr {
             background-color: transparent;
             border: 1px @color-border-highlight solid;
@@ -58,6 +55,7 @@
                 font-weight: normal;
                 .user-select(none);
                 border-left: @table-border-tablecell;
+                overflow: hidden;
                 &:first-child {
                     border-left: none;
                 }
@@ -72,7 +70,7 @@
         border-collapse: collapse;
         border-spacing: 0;
         width: 100%;
-        table-layout: auto;
+        table-layout: fixed;
     }
     tr {
         background-color: @color-table-oddRow;
@@ -94,8 +92,5 @@
     height: 1px;
     overflow: hidden;
     position: absolute;
-    table {
-        table-layout: auto;
-    }
 }
 

--- a/src/less/table-theme.less
+++ b/src/less/table-theme.less
@@ -8,7 +8,7 @@
 @color-border-highlight: @theme-base-color-medium;
 @color-gradient-light: @theme-light;
 @color-gradient-dark: @theme-base-color-medium;
-@color-highlight-hover: #a7c8dd;
+@color-highlight-hover: #D2E0E6;
 @color-legend: #0081C2;
 @color-table-selected-background: lighten(#a7c8dd, 15%);
 @color-table-cellBorder : @theme-base-color-medium;


### PR DESCRIPTION
Converting the table to use column group handling.

Overall simplifies the table definition.  No more listening on resize to resize TD and THs.  It is done automatically.  I am not pulling the widths from the classes assigned.  Lets say the first column is something like

<th class="name">Name</th>

I do not look at the .name class to see if it defines a width and if it does extract this and set it on the column.  Note: When using columns in this manner, the "name" class would also need to be modified.

Fixes #46 
Fixes #43 
Fixes #6 
