### PR TITLE
Performance fix for initial tables

### DIFF
--- a/src/directives/highlight-column.js
+++ b/src/directives/highlight-column.js
@@ -57,7 +57,12 @@
                     var observer = null;
                     var index = element.parent().children().toArray().indexOf(element[0]);
                     if (index !== undefined) {
-                        observer = trackNewInsertions(tableId, index);
+                        $timeout(function() {
+                            var tds = $("#" + tableId + " td:nth-child(" + (index+1) + ")");
+                            addListeners(tds);
+                            observer = trackNewInsertions(tableId, index);
+                        }, 0, false);
+                        
                     }
                     scope.$on('$destroy', function() {
                         if (observer !== null) {


### PR DESCRIPTION
We should only track insertions, once the table has been processed.
Therefore it should only be added after the initial table rows are bound
- will need to evaluate on a delayed insertion (just as server response)
