### PR TITLE
Fix handling of column-menu and firefox issues

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -19,7 +19,7 @@
                     }
                 }, 500);
 
-                
+
                 $scope.$on(stgControllerEvents.selection, function(evt, sRows) {
                     $scope.currentSelection = sRows;
                 });
@@ -32,11 +32,15 @@
                 };
                 $scope.toggleHiddenColumn = function() {
                     $scope.hideColumns = !$scope.hideColumns;
-                    var elm = $("th[col-visibility]");
-                    elm.each(function(indx, el) {
-                        var tableId = ScrollingTableHelper.getIdOfContainingTable($(el));
-                        ColumnVisibilityService.setColumnVisibility(tableId, el.cellIndex, $scope.hideColumns);
+                    var searchTypes = ["col-visibility", "data-col-visibility"];
+                    angular.forEach(searchTypes, function(searchType) {
+                        var elm = $("th[" + searchType + "]");
+                        elm.each(function(indx, el) {
+                            var tableId = ScrollingTableHelper.getIdOfContainingTable($(el));
+                            ColumnVisibilityService.setColumnVisibility(tableId, el.cellIndex, $scope.hideColumns);
+                        });
                     });
+
                 };
             }
             ).config(function($logProvider) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,6 +13,9 @@
             .name {
                 width: 150px;
             }
+            .attention {
+                background-color: #C6E746;
+            }
         </style>
     </head>
     <body>
@@ -21,7 +24,7 @@
 
             <div style="margin-top: 3em;">5 Rows - 22 Columns
                 <br/>
-            <img src="../dist/resources/images/edit-column-icon.png" add-visibility-menu="" style="float:left;"/>
+            <img src="../dist/resources/images/edit-column-icon.png" alt="menu" data-table-visibility-menu="" style="float:left;"/>
             <br/>
             <table
                 data-stg-scrolling-table
@@ -30,17 +33,17 @@
                 style="width: 100%; ">
                 <thead>
                     <tr>
-                        <th data-column-sortable class="name" data-col="rate">Name</th>
-                        <th style="background-color:red;" col-visibility="{{hideColumns}}">Hidden Number</th>
+                        <th data-column-sortable class="name" data-col="rate">Your Name</th>
+                        <th class="attention" data-col-visibility="{{hideColumns}}">Hidden Number</th>
                         <th class="Phone" width="100px">Phone Number</th>
-                        <th col-fixed="true">Phone Number</th>
+                        <th data-col-fixed="true">Phone Number</th>
                         <th>Phone Number</th>
                         <th>Phone Number</th>
                         <th>Phone Number</th>
                         <th>Phone Number</th>
                         <th>Phone Number</th>
-                        <th style="background-color:red;" col-visibility="{{hideColumns}}">Phone Number</th>
-                        <th style="background-color:red;" col-visibility="{{hideColumns}}">Phone Number</th>
+                        <th class="attention" data-col-visibility="{{hideColumns}}">Phone Number</th>
+                        <th class="attention" data-col-visibility="{{hideColumns}}">Phone Number</th>
                         <th>Phone Number</th>
                         <th>Phone Number</th>
                         <th>Phone Number</th>
@@ -86,7 +89,7 @@
            
 
             <div style="margin-top: 3em;">50 Rows - 22 Columns (hover over headers to highlight data columns)
-            <img src="../dist/resources/images/edit-column-icon.png" add-visibility-menu="" style="float:right;"/>
+            <img src="../dist/resources/images/edit-column-icon.png" alt="menu" data-table-visibility-menu="" style="float:right;"/>
             <br/>
             <table
                 data-stg-scrolling-table

--- a/src/directives/scrolling-table.js
+++ b/src/directives/scrolling-table.js
@@ -131,10 +131,6 @@ MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
             };
             checkForChanges();
         }
-        
-        function isIE() {
-            return ($window.navigator.userAgent.indexOf('MSIE') !== -1 || $window.navigator.appVersion.indexOf('Trident/') > 0);
-        }
 
         function calculateScrollerHeight(tableWrapper) {
             var scroller = tableWrapper.find('.scroller');

--- a/src/less/scrolling-table.less
+++ b/src/less/scrolling-table.less
@@ -35,6 +35,8 @@
             }
         }
         .empty-msg {
+            border-left: @table-border-tablecell;
+            border-right: @table-border-tablecell;
             div {
                 padding: 5px 10px;
                 font-size: @table-font-size;
@@ -93,15 +95,12 @@
 
 .col-hidden {
     display: none;
-    // visibility: collapse;
 }
 
 .column-menu {
     background-color: @color-background-menu;
     border: @table-border-column-visibility;
     position: absolute;
-    top: 0px;
-    left: 0px;
     overflow-y: auto;
     width: 170px;
     height: 125px;
@@ -115,8 +114,8 @@
             font-size: 0.75em;
         } 
     }
-
 }
+
 .minWidthHeaders {
     width: 1px;
     height: 1px;

--- a/src/less/table-theme.less
+++ b/src/less/table-theme.less
@@ -17,8 +17,7 @@
 @color-table-oddRow: @theme-light;
 @color-text: #000000;
 @color-text-shadow: darken(@theme-light, 4%);
-@color-background-menu: darken(@theme-light, 7%);
-
+@color-background-menu: #FAFAFA;
 
 @table-font-size: 12px;
 @table-border-column-visibility: 1px @theme-dark solid;

--- a/src/util/global-functions.js
+++ b/src/util/global-functions.js
@@ -1,4 +1,12 @@
-var MouseClickObserver = function() {
+function isFirefox() {
+    return (window.mozInnerScreenX !== undefined);
+};
+
+function isIE() {
+    return (window.navigator.userAgent.indexOf('MSIE') !== -1 || window.navigator.appVersion.indexOf('Trident/') > 0);
+}
+
+var MouseClickObserver = function($, angular, window) {
     var containers = [];
 
     this.addContainer = function(container) {
@@ -11,7 +19,7 @@ var MouseClickObserver = function() {
         if (!found) {
             containers.push(container);
         }
-        $(window.document).mouseup(processEvent);
+        $(window.document).on("mouseup", processEvent);
     };
 
     var processEvent = function(e) {
@@ -19,20 +27,19 @@ var MouseClickObserver = function() {
         for (var i = 0; i < containers.length; i++) {
             var container = $(containers[i].selector);
             if (!container.is(e.target) && container.has(e.target).length === 0) {
-                container.hide();
-                index = i;
+                if (container.css("display") !== "none") {
+                    containers.splice(i, 1);
+                    if (containers.length === 0) {
+                        $(window.document).off("mouseup");
+                    }
+                    container.hide();
+                }
                 break;
             } else {
                 // e.stopPropagation();
             }
         }
-        /*if (index >= 0) {
-         containers.splice(index, 1);
-         if (containers.length === 0) {
-         $(window.document).off("mouseup");
-         }
-         }*/
     };
 
     return this;
-}();
+}(jQuery, angular, window);


### PR DESCRIPTION
Fix the handling of column-menu whereby there were multiple copies of
the menu in the DOM.  Now only one exists and it will self-deregister
upon hide().

Also attempt to resolve the firefox issue with hidden columns taking up
calculated space in TDs even though not visible.

Fixes #57
